### PR TITLE
Using AuthType from App.Config instead of Hardcoding

### DIFF
--- a/PokemonGo/RocketAPI/Console/Settings.cs
+++ b/PokemonGo/RocketAPI/Console/Settings.cs
@@ -19,7 +19,7 @@ namespace PokemonGo.RocketAPI.Console
         public bool EvolveAllGivenPokemons => GetSetting() != string.Empty ? System.Convert.ToBoolean(GetSetting(), CultureInfo.InvariantCulture) : false;
 
 
-        public AuthType AuthType => AuthType.Google; // what authentication method you want
+        public AuthType AuthType => (GetSetting() != string.Empty ? GetSetting() : "Ptc") == "Ptc" ? AuthType.Ptc : AuthType.Google;
         public string PtcUsername => GetSetting() != string.Empty ? GetSetting() : "username";
         public string PtcPassword => GetSetting() != string.Empty ? GetSetting() : "password";
 


### PR DESCRIPTION
I don't get why you should not use the Data in App.Config, eventhough it is already in there.
It was inconvenient to change one part in App.Config and one Part in Settings.cs.