### PR TITLE
Conserve better Pokeballs for strong CP Pokemon

### DIFF
--- a/PokemonGo/RocketAPI/Client.cs
+++ b/PokemonGo/RocketAPI/Client.cs
@@ -50,12 +50,12 @@ namespace PokemonGo.RocketAPI
         }
 
         public async Task<CatchPokemonResponse> CatchPokemon(ulong encounterId, string spawnPointGuid, double pokemonLat,
-            double pokemonLng, MiscEnums.Item pokeball)
+            double pokemonLng, MiscEnums.Item pokeball, int? pokemonCP)
         {
             var customRequest = new Request.Types.CatchPokemonRequest
             {
                 EncounterId = encounterId,
-                Pokeball = (int) GetBestBall().Result,
+                Pokeball = (int) GetBestBall(pokemonCP).Result,
                 SpawnPointGuid = spawnPointGuid,
                 HitPokemon = 1,
                 NormalizedReticleSize = Utils.FloatAsUlong(1.950),
@@ -137,7 +137,7 @@ namespace PokemonGo.RocketAPI
                         releasePokemonRequest);
         }
 
-        private async Task<MiscEnums.Item> GetBestBall()
+        private async Task<MiscEnums.Item> GetBestBall(int? pokemonCP)
         {
             var inventory = await GetInventory();
 
@@ -159,14 +159,25 @@ namespace PokemonGo.RocketAPI
             var masterBallsCount = ballCollection.Where(p => p.ItemId == MiscEnums.Item.ITEM_MASTER_BALL).
                 DefaultIfEmpty(new {ItemId = MiscEnums.Item.ITEM_MASTER_BALL, Amount = 0}).FirstOrDefault().Amount;
 
-            if (masterBallsCount > 0)
+            // Use better balls for high CP pokemon
+            if (masterBallsCount > 0 && pokemonCP >= 1000)
                 return MiscEnums.Item.ITEM_MASTER_BALL;
 
-            if (ultraBallsCount > 0)
+            if (ultraBallsCount > 0 && pokemonCP >= 600)
                 return MiscEnums.Item.ITEM_ULTRA_BALL;
 
-            if (greatBallsCount > 0)
+            if (greatBallsCount > 0 && pokemonCP >= 350)
                 return MiscEnums.Item.ITEM_GREAT_BALL;
+
+            // If low CP pokemon, but no more pokeballs; only use better balls if pokemon are of semi-worthy quality
+            if (pokeBallsCount > 0)
+                return MiscEnums.Item.ITEM_POKE_BALL;
+            else if ((greatBallsCount < 40 && pokemonCP >= 200) || greatBallsCount >= 40)
+                return MiscEnums.Item.ITEM_GREAT_BALL;
+            else if (ultraBallsCount > 0 && pokemonCP >= 500)
+                return MiscEnums.Item.ITEM_ULTRA_BALL;
+            else if (masterBallsCount > 0 && pokemonCP >= 700)
+                return MiscEnums.Item.ITEM_MASTER_BALL;
 
             return MiscEnums.Item.ITEM_POKE_BALL;
         }

--- a/PokemonGo/RocketAPI/Client.cs
+++ b/PokemonGo/RocketAPI/Client.cs
@@ -172,7 +172,7 @@ namespace PokemonGo.RocketAPI
             // If low CP pokemon, but no more pokeballs; only use better balls if pokemon are of semi-worthy quality
             if (pokeBallsCount > 0)
                 return MiscEnums.Item.ITEM_POKE_BALL;
-            else if ((greatBallsCount < 40 && pokemonCP >= 200) || greatBallsCount >= 40)
+            else if ((greatBallsCount < 40 && greatBallsCount > 0 && pokemonCP >= 200) || greatBallsCount >= 40)
                 return MiscEnums.Item.ITEM_GREAT_BALL;
             else if (ultraBallsCount > 0 && pokemonCP >= 500)
                 return MiscEnums.Item.ITEM_ULTRA_BALL;

--- a/PokemonGo/RocketAPI/Console/Program.cs
+++ b/PokemonGo/RocketAPI/Console/Program.cs
@@ -168,19 +168,20 @@ namespace PokemonGo.RocketAPI.Console
             {
                 var update = await client.UpdatePlayerLocation(pokemon.Latitude, pokemon.Longitude);
                 var encounterPokemonResponse = await client.EncounterPokemon(pokemon.EncounterId, pokemon.SpawnpointId);
+                var pokemonCP = encounterPokemonResponse?.WildPokemon?.PokemonData?.Cp;
                 CatchPokemonResponse caughtPokemonResponse;
                 do
                 {
                     caughtPokemonResponse =
                         await
                             client.CatchPokemon(pokemon.EncounterId, pokemon.SpawnpointId, pokemon.Latitude,
-                                pokemon.Longitude, MiscEnums.Item.ITEM_POKE_BALL);
+                                pokemon.Longitude, MiscEnums.Item.ITEM_POKE_BALL, pokemonCP);
                     ; //note: reverted from settings because this should not be part of settings but part of logic
                 } while (caughtPokemonResponse.Status == CatchPokemonResponse.Types.CatchStatus.CatchMissed);
                 System.Console.WriteLine(caughtPokemonResponse.Status ==
                                          CatchPokemonResponse.Types.CatchStatus.CatchSuccess
-                    ? $"[{DateTime.Now.ToString("HH:mm:ss")}] We caught a {pokemon.PokemonId} with CP {encounterPokemonResponse?.WildPokemon?.PokemonData?.Cp}"
-                    : $"[{DateTime.Now.ToString("HH:mm:ss")}] {pokemon.PokemonId} with CP {encounterPokemonResponse?.WildPokemon?.PokemonData?.Cp} got away..");
+                    ? $"[{DateTime.Now.ToString("HH:mm:ss")}] We caught a {pokemon.PokemonId} with CP {pokemonCP}"
+                    : $"[{DateTime.Now.ToString("HH:mm:ss")}] {pokemon.PokemonId} with CP {pokemonCP} got away..");
 
                 await Task.Delay(5000);
 


### PR DESCRIPTION
Instead of wasting good Pokeballs on weak Pokemon, only use them when appropriate.
If no regular Pokeballs left, only use better Pokeballs to capture worthwhile Pokemon instead of wasting them all on 10 CP Pidgeys.